### PR TITLE
fix dumplicated translations of merged cells in word tables; fix ArrayFormula cell error in excel

### DIFF
--- a/python/translate/common.py
+++ b/python/translate/common.py
@@ -5,6 +5,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from openpyxl.worksheet.formula import ArrayFormula
 
 def is_all_punc(strings):
     if isinstance(strings, datetime.time):
@@ -12,6 +13,8 @@ def is_all_punc(strings):
     elif isinstance(strings, datetime.datetime):
         return True
     elif isinstance(strings, (int, float, complex)):
+        return True
+    elif isinstance(strings, (ArrayFormula)):
         return True
     # print(type(strings))
     chinese_punctuations=get_chinese_punctuation()


### PR DESCRIPTION
1.word文档中的表格，若存在合并单元格，会被重复读取、翻译，同一个单元格内出现多份译文。修复了横向合并单元格的这个问题；纵向合并的单元格搞不定。代码中写了思路，没法断点调试、调不出来。（如原版复现不出来，可以切换到原文+译文模式）
2.修复了excel的单元格为ArrayFormula格式时报错的问题